### PR TITLE
Adding legal notice to 'ai:models:create'

### DIFF
--- a/src/commands/ai/models/create.ts
+++ b/src/commands/ai/models/create.ts
@@ -36,6 +36,11 @@ export default class Create extends Command {
     const {app, as, confirm} = flags
     const {model_name: modelName} = args
 
+    ux.warn(
+      '\n\nHeroku Managed Inference and Agents is a pilot service. Currently offered models are powered by AWS Bedrock. ' +
+      'Generative AI may provide inaccurate information.\n'
+    )
+
     try {
       const addon = await createAddon(
         this.heroku,

--- a/test/commands/ai/models/create.test.ts
+++ b/test/commands/ai/models/create.test.ts
@@ -44,8 +44,10 @@ describe('ai:models:create', function () {
         'claude-3-haiku',
         '--app=app1',
       ])
-      expect(stripAnsi(stderr.output)).to.eq(heredoc`
-        Creating inference:claude-3-haiku on app1...
+      expect(stripAnsi(stderr.output)).to.include(
+        'Heroku Managed Inference and Agents is a pilot service.'
+      )
+      expect(stripAnsi(stderr.output)).to.include(heredoc`
         Creating inference:claude-3-haiku on app1... free
       `)
       expect(stripAnsi(stdout.output)).to.eq(heredoc`
@@ -73,8 +75,10 @@ describe('ai:models:create', function () {
         '--app=app1',
         '--as=CLAUDE_HAIKU',
       ])
-      expect(stripAnsi(stderr.output)).to.eq(heredoc`
-        Creating inference:claude-3-haiku on app1...
+      expect(stripAnsi(stderr.output)).to.include(
+        'Heroku Managed Inference and Agents is a pilot service.'
+      )
+      expect(stripAnsi(stderr.output)).to.include(heredoc`
         Creating inference:claude-3-haiku on app1... free
       `)
       expect(stripAnsi(stdout.output)).to.eq(heredoc`


### PR DESCRIPTION
## Description

Here we're adding a disclaimer notice to be shown when a new AI model is created.

## Test instructions
- Download this branch and build.
- Export the required env vars for AI plugin testing: ```export HEROKU_INFERENCE_HOST="staging.inference.herokai.com"``` and ```export HEROKU_INFERENCE_ADDON="inference-staging"```.
- Run ```./bin/run ai:models:create claude-3-sonnet -a <test-app>``` and verify that the legal notice is displayed.
- Destroy the resource with ```./bin/run ai:models:destroy <ATTACHMENT_NAME> -a <test-app> --confirm <test-app>```

## SOC2 Compliance
GUS Work Item: [W-17041683](https://gus.lightning.force.com/a07EE000023rqE1YAI)