### PR TITLE
fix(create): add alias & model slug

### DIFF
--- a/src/lib/ai/models/create_addon.ts
+++ b/src/lib/ai/models/create_addon.ts
@@ -45,7 +45,7 @@ export default async function (
     ux.log(addon.provision_message)
   }
 
-  ux.log(`Model name: ${addon.name}\nModel alias: ${options.as}`)
+  ux.log(`Model name: ${color.configVar(addon.name)}${options.as ? `\nModel alias: ${color.configVar(options.as)}` : ''}`)
 
   ux.log(
     `Added ${addon.config_vars.map((c: string) => color.configVar(c)).join(', ')} to ${color.app(addon.app.name)}`

--- a/test/commands/ai/models/create.test.ts
+++ b/test/commands/ai/models/create.test.ts
@@ -52,6 +52,7 @@ describe('ai:models:create', function () {
       `)
       expect(stripAnsi(stdout.output)).to.eq(heredoc`
         Heroku AI model resource provisioned successfully
+        Model name: inference-regular-74659
         Added INFERENCE_KEY, INFERENCE_MODEL_ID, INFERENCE_URL to app1
         Use heroku ai:docs to view documentation.
       `)
@@ -83,6 +84,8 @@ describe('ai:models:create', function () {
       `)
       expect(stripAnsi(stdout.output)).to.eq(heredoc`
         Heroku AI model resource provisioned successfully
+        Model name: inference-regular-74659
+        Model alias: CLAUDE_HAIKU
         Added CLAUDE_HAIKU_KEY, CLAUDE_HAIKU_ID, CLAUDE_HAIKU_URL to app1
         Use heroku ai:docs to view documentation.
       `)
@@ -119,6 +122,8 @@ describe('ai:models:create', function () {
       expect(stripAnsi(stderr.output)).to.contain('Adding CLAUDE_HAIKU to app app1 would overwrite existing vars')
       expect(stripAnsi(stdout.output)).to.eq(heredoc`
         Heroku AI model resource provisioned successfully
+        Model name: inference-regular-74659
+        Model alias: CLAUDE_HAIKU
         Added CLAUDE_HAIKU_KEY, CLAUDE_HAIKU_ID, CLAUDE_HAIKU_URL to app1
         Use heroku ai:docs to view documentation.
       `)
@@ -145,6 +150,8 @@ describe('ai:models:create', function () {
       expect(stripAnsi(stderr.output)).not.to.contain('Adding CLAUDE_HAIKU to app app1 would overwrite existing vars')
       expect(stripAnsi(stdout.output)).to.eq(heredoc`
         Heroku AI model resource provisioned successfully
+        Model name: inference-regular-74659
+        Model alias: CLAUDE_HAIKU
         Added CLAUDE_HAIKU_KEY, CLAUDE_HAIKU_ID, CLAUDE_HAIKU_URL to app1
         Use heroku ai:docs to view documentation.
       `)


### PR DESCRIPTION
## Description

[Work Item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000024paq2YAA/view)

This PR adds the model alias and model slug name to the output of the `heroku ai:models:create` command. If an alias is not provided, the output will only show the model slug name.

### Before
![Screenshot 2024-12-02 at 11 13 28 AM](https://github.com/user-attachments/assets/e14a8170-c5a7-4acc-9211-83d89f1a0e10)

### After
### _With Model Slug Name & Alias_
![Screenshot 2024-12-02 at 11 11 11 AM](https://github.com/user-attachments/assets/edd2f639-e840-4223-91b3-4b4c8a49f423)


### _With Model Slug Name_
![Screenshot 2024-12-02 at 11 07 49 AM](https://github.com/user-attachments/assets/20391b26-bc73-4410-a84e-6511b72bf105)

## Testing
**NOTE:** Until the addon service name is updated to `heroku-inference` instead of `inference`, make sure you export the correct environment variable via `export HEROKU_INFERENCE_ADDON="inference-staging"`

1. Pull down branch & `yarn` it up
2. Create a test app for AI model addon via `heroku apps:create test-cli-plugin-ai`
3. Create an AI model addon via `./bin/run ai:models:create claude-3-5-sonnet --as EXAMPLE_MODEL_ALIAS --app testing-deploy`
4. Confirm that model slug and alias are outputted after model creation
5. Destroy current AI model addon via `heroku ai:models:destroy EXAMPLE_MODEL_ALIAS --app testing-deploy`
6. Create an AI model addon (without alias) via `./bin/run ai:models:create claude-3-5-sonnet --app testing-deploy`
7. Confirm that model slug is outputted after model creation