### PR TITLE
update(docs): update dev center link

### DIFF
--- a/src/commands/ai/docs.ts
+++ b/src/commands/ai/docs.ts
@@ -3,7 +3,7 @@ import {openUrl} from '../../lib/open-url'
 import Command from '../../lib/base'
 
 export default class Docs extends Command {
-  static defaultUrl = 'https://devcenter.heroku.com/articles/ai'
+  static defaultUrl = 'https://devcenter.heroku.com/articles/heroku-inference-cli-commands'
   static description = 'Opens documentation for Heroku AI in your web browser.'
   static flags = {
     browser: flags.string({description: 'browser to open docs with (example: "firefox", "safari")'}),


### PR DESCRIPTION
## Description
[Work Item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000024pVdSYAU/view)

This PR updates the `default` URL for the `heroku ai:docs` command. This will be the official URL for the MIA plugin documentation.