### PR TITLE
Revert "chore(ai): update scope & publishing config"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
-  "name": "@heroku-cli/plugin-ai",
+  "name": "@heroku/plugin-ai",
   "description": "Heroku CLI plugin for Heroku AI add-on",
   "version": "0.0.5",
   "author": "Heroku",
   "bugs": "https://github.com/heroku/heroku-cli-plugin-ai/issues",
+  "publishConfig": {
+    "access": "restricted"
+  },
   "dependencies": {
     "@heroku-cli/color": "^2",
     "@heroku-cli/command": "^11",


### PR DESCRIPTION
Reverts heroku/heroku-cli-plugin-ai#46 due to an [issue](https://salesforce-internal.slack.com/archives/C07E9UU8F7V/p1733430034532759?thread_ts=1733428989.991679&cid=C07E9UU8F7V) being investigated and requires another private release to confirm potential chat completions bug.