### PR TITLE
fix: update ai:models:create output for config vars

### DIFF
--- a/src/lib/ai/models/create_addon.ts
+++ b/src/lib/ai/models/create_addon.ts
@@ -48,7 +48,7 @@ export default async function (
   ux.log(`Model name: ${color.configVar(addon.name)}${options.as ? `\nModel alias: ${color.configVar(options.as)}` : ''}`)
 
   ux.log(
-    `Run ${color.cmd(`heroku config -a ${addon.app.name}`)} to view model config vars associated with this app.`
+    `Run ${color.cmd(`'heroku config -a ${addon.app.name}'`)} to view model config vars associated with this app.`
   )
 
   return addon

--- a/test/commands/ai/models/create.test.ts
+++ b/test/commands/ai/models/create.test.ts
@@ -53,7 +53,7 @@ describe('ai:models:create', function () {
       expect(stripAnsi(stdout.output)).to.eq(heredoc`
         Heroku AI model resource provisioned successfully
         Model name: inference-regular-74659
-        Run heroku config -a app1 to view model config vars associated with this app.
+        Run 'heroku config -a app1' to view model config vars associated with this app.
         Use heroku ai:docs to view documentation.
       `)
     })
@@ -86,7 +86,7 @@ describe('ai:models:create', function () {
         Heroku AI model resource provisioned successfully
         Model name: inference-regular-74659
         Model alias: CLAUDE_HAIKU
-        Run heroku config -a app1 to view model config vars associated with this app.
+        Run 'heroku config -a app1' to view model config vars associated with this app.
         Use heroku ai:docs to view documentation.
       `)
     })
@@ -124,7 +124,7 @@ describe('ai:models:create', function () {
         Heroku AI model resource provisioned successfully
         Model name: inference-regular-74659
         Model alias: CLAUDE_HAIKU
-        Run heroku config -a app1 to view model config vars associated with this app.
+        Run 'heroku config -a app1' to view model config vars associated with this app.
         Use heroku ai:docs to view documentation.
       `)
     })
@@ -152,7 +152,7 @@ describe('ai:models:create', function () {
         Heroku AI model resource provisioned successfully
         Model name: inference-regular-74659
         Model alias: CLAUDE_HAIKU
-        Run heroku config -a app1 to view model config vars associated with this app.
+        Run 'heroku config -a app1' to view model config vars associated with this app.
         Use heroku ai:docs to view documentation.
       `)
     })


### PR DESCRIPTION
## Description

This PR updates the output from the `ai:models:create` command to direct the user to use the suggested command to retrieve all config var info for the newly provisioned AI model resource.

### Before
![Screenshot 2024-12-06 at 1 22 33 PM](https://github.com/user-attachments/assets/d7873f47-7cf6-4e5e-aba9-ad182fa14115)


### After
![Screenshot 2024-12-06 at 1 21 14 PM](https://github.com/user-attachments/assets/36b97c5a-18ca-4271-95bf-4bdee9cc8d96)

