### PR TITLE
Revert "Revert "chore(ai): update scope & publishing config""

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,9 @@
 {
-  "name": "@heroku/plugin-ai",
+  "name": "@heroku-cli/plugin-ai",
   "description": "Heroku CLI plugin for Heroku AI add-on",
   "version": "0.0.6",
   "author": "Heroku",
   "bugs": "https://github.com/heroku/heroku-cli-plugin-ai/issues",
-  "publishConfig": {
-    "access": "restricted"
-  },
   "dependencies": {
     "@heroku-cli/color": "^2",
     "@heroku-cli/command": "^11",


### PR DESCRIPTION
Reverts heroku/heroku-cli-plugin-ai#49.

## Description

[Work Item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000026JxK2YAK/view)

This PR updates the `npm` org ownership and publishing scope in `package.json`. This is in preparation for the MIA plugin release.

**NOTE:** We will only make this repo public once we are just about to publish to `npm`.