### PR TITLE
fix: update not found error message in base class and tests

### DIFF
--- a/src/lib/base.ts
+++ b/src/lib/base.ts
@@ -9,7 +9,7 @@ export class NotFound extends Error {
   constructor(addonIdentifier: string, appIdentifier?: string) {
     const message = heredoc`
       We can’t find a model resource called ${color.yellow(addonIdentifier)}${appIdentifier ? ` on ${color.app(appIdentifier)}` : ''}.
-      Run ${color.cmd(`heroku ai:models:info --app ${appIdentifier ? appIdentifier : '<value>'}`)} to see a list of model resources.
+      Run ${color.cmd(`heroku addons --app ${appIdentifier ? appIdentifier : '<value>'}`)} to see a list of model resources.
     `
     super(message)
   }

--- a/test/lib/base.test.ts
+++ b/test/lib/base.test.ts
@@ -153,7 +153,7 @@ describe('attempt a request using the Heroku AI client', function () {
           const {message} = error as Error
           expect(stripAnsi(message)).to.equal(heredoc`
             We can’t find a model resource called inference-inexistent-00001.
-            Run heroku ai:models:info --app <value> to see a list of model resources.
+            Run heroku addons --app <value> to see a list of model resources.
           `)
         }
 
@@ -180,7 +180,7 @@ describe('attempt a request using the Heroku AI client', function () {
           const {message} = error as Error
           expect(stripAnsi(message)).to.equal(heredoc`
             We can’t find a model resource called ${addon1.name} on app2.
-            Run heroku ai:models:info --app app2 to see a list of model resources.
+            Run heroku addons --app app2 to see a list of model resources.
           `)
         }
 


### PR DESCRIPTION
Updates the not found error in the base class to direct users to run `heroku addons` instead of `heroku ai:models:info`.