### PR TITLE
fix: update @heroku/cli-command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/heroku/heroku-cli-plugin-ai/issues",
   "dependencies": {
     "@heroku-cli/color": "^2",
-    "@heroku-cli/command": "^11",
+    "@heroku-cli/command": "^11.4.0",
     "@heroku-cli/schema": "^1.0.25",
     "@oclif/core": "^2.16.0",
     "@oclif/plugin-help": "^5",
@@ -15,6 +15,7 @@
     "tsheredoc": "^1"
   },
   "devDependencies": {
+    "@heroku/http-call": "^5.4.0",
     "@oclif/test": "^2.3.28",
     "@types/mocha": "^10",
     "@types/nock": "^11",
@@ -29,7 +30,6 @@
     "eslint-import-resolver-typescript": "^3",
     "eslint-plugin-import": "^2",
     "eslint-plugin-mocha": "^10",
-    "http-call": "^5",
     "mocha": "^10",
     "nock": "^13",
     "np": "7.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -222,18 +222,18 @@
     supports-color "^7.2.0"
     tslib "^1.9.3"
 
-"@heroku-cli/command@^11":
-  version "11.3.1"
-  resolved "https://registry.yarnpkg.com/@heroku-cli/command/-/command-11.3.1.tgz#74671ee8149d31cc5beb0e7e8e369fe2dd7aeac2"
-  integrity sha512-n3+KgMmXScZDVEQu76mffzOJoQ5JyRYzzJ7uj3cNyAOK61xjaS1wEE86DBb57C1MlnjKtO7onJETBm2SMLdUIQ==
+"@heroku-cli/command@^11.4.0":
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/@heroku-cli/command/-/command-11.4.0.tgz#301e190e56ac228f22a4a0b327a870509f63cfb9"
+  integrity sha512-A0n4IqLiS4ukY26Ha1X4s1gRfJrHwxkULWSC4SuPhktN1VHOHka76WKdmF+cEyfSysz8ui8KpTJz704kL2Y3Vw==
   dependencies:
     "@heroku-cli/color" "^2.0.1"
+    "@heroku/http-call" "^5.4.0"
     "@oclif/core" "^2.16.0"
     cli-ux "^6.0.9"
-    debug "^4.3.4"
+    debug "^4.4.0"
     fs-extra "^9.1.0"
     heroku-client "^3.1.0"
-    http-call "^5.3.0"
     netrc-parser "^3.1.6"
     open "^8.4.2"
     uuid "^8.3.0"
@@ -244,6 +244,17 @@
   version "1.0.25"
   resolved "https://registry.yarnpkg.com/@heroku-cli/schema/-/schema-1.0.25.tgz#175d489d82c2ff0be700fe9fab8590b64c7e4f39"
   integrity sha512-7V6/WdTHrsvpqeqttm4zhzVJyt/Us/Cz9oS4yure4JdLtwlr2eF6PvlDLA5ZIvBybMtSDyxhHid0PeshKLtwxw==
+
+"@heroku/http-call@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@heroku/http-call/-/http-call-5.4.0.tgz#1f3d804d17888c61d375d2dcb399f405781132e8"
+  integrity sha512-8ys8jFP9l1wFXNmhmUb/EKLY/3flGzd7lv3x5MCw+36ov+qR9OFgk7bNHn3s+FPUKRSf/2GmKJjJmgnaD1YMmA==
+  dependencies:
+    content-type "^1.0.5"
+    debug "^4.4.0"
+    is-retry-allowed "^2.2.0"
+    is-stream "^2.0.0"
+    tunnel-agent "^0.6.0"
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
@@ -1843,7 +1854,7 @@ confusing-browser-globals@1.0.10:
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz#30d1e7f3d1b882b25ec4933d1d1adac353d20a59"
   integrity sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==
 
-content-type@^1.0.4:
+content-type@^1.0.4, content-type@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
@@ -2035,6 +2046,13 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.3, debug@^4.3
   integrity sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==
   dependencies:
     ms "2.1.2"
+
+debug@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
+  integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
+  dependencies:
+    ms "^2.1.3"
 
 decamelize-keys@^1.1.0:
   version "1.1.1"
@@ -3721,7 +3739,7 @@ http-cache-semantics@^4.0.0:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
   integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
 
-http-call@^5, http-call@^5.1.2, http-call@^5.2.2, http-call@^5.3.0:
+http-call@^5.1.2, http-call@^5.2.2:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/http-call/-/http-call-5.3.0.tgz#4ded815b13f423de176eb0942d69c43b25b148db"
   integrity sha512-ahwimsC23ICE4kPl9xTBjKB4inbRaeLyZeRunC/1Jy/Z6X8tv22MEAjK+KBOMSVLaqXPTTmd8638waVIKLGx2w==
@@ -4205,6 +4223,11 @@ is-retry-allowed@^1.0.0, is-retry-allowed@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
   integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
+
+is-retry-allowed@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz#88f34cbd236e043e71b6932d09b0c65fb7b4d71d"
+  integrity sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==
 
 is-scoped@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fixes a bug that caused some requests to time out and print an error message with a type error.

## Testing
- Pull down this branch and run `yarn && yarn build`
- Run `./bin/run ai:models:call inference-animate-42224 -a test-cli-plugin-ai -p "what is candy?"` (internal team members should have access to this app and model)
- Request should succeed