### PR TITLE
chore: add devcenter github workflow

### DIFF
--- a/.github/workflows/devcenter.yml
+++ b/.github/workflows/devcenter.yml
@@ -1,0 +1,21 @@
+name: Update AI Plugin Command DevCenter Documentation
+
+on:
+  workflow_dispatch:
+    inputs:
+      isStableRelease:
+        type: boolean
+        description: Is this a stable/prod release?
+        required: true
+        default: false
+
+jobs:
+  update-plugin-docs:
+    name: Update AI plugin DevCenter command docs
+    uses: heroku/frontend-github-workflows/push-to-devcenter.yml@main
+    secrets: 
+      HEROKU_DEVCENTER_API_KEY: ${{ secrets.HEROKU_DEVCENTER_API_KEY }}
+    with:
+      isStableRelease: ${{ inputs.isStableRelease }}
+      articleTitle: Heroku Managed Inference and Agent Add-on CLI Commands
+      articleID: 8759


### PR DESCRIPTION
Adds a workflow for pushing the AI plugin command docs to the devcenter doc [Heroku Managed Inference and Agent Add-on CLI Commands](https://devcenter.heroku.com/articles/heroku-inference-cli-commands#). This workflow makes use of the [push-to-devcenter](https://github.com/heroku/frontend-github-workflows/blob/main/.github/workflows/push-to-devcenter.yml) shared workflow.

For testing purposes, this workflow can only be run manually for now. Once I know it works, I will update the workflow to run automatically when a github release is published.