### PR TITLE
Rename model name to resource name

### DIFF
--- a/src/lib/ai/models/create_addon.ts
+++ b/src/lib/ai/models/create_addon.ts
@@ -45,7 +45,7 @@ export default async function (
     ux.log(addon.provision_message)
   }
 
-  ux.log(`Resource name: ${color.configVar(addon.name)}${options.as ? `\nModel alias: ${color.configVar(options.as)}` : ''}`)
+  ux.log(`Resource name: ${color.configVar(addon.name)}${options.as ? `\nResource alias: ${color.configVar(options.as)}` : ''}`)
 
   ux.log(
     `Run ${color.cmd(`'heroku config -a ${addon.app.name}'`)} to view model config vars associated with this app.`

--- a/src/lib/ai/models/create_addon.ts
+++ b/src/lib/ai/models/create_addon.ts
@@ -45,7 +45,7 @@ export default async function (
     ux.log(addon.provision_message)
   }
 
-  ux.log(`Model name: ${color.configVar(addon.name)}${options.as ? `\nModel alias: ${color.configVar(options.as)}` : ''}`)
+  ux.log(`Resource name: ${color.configVar(addon.name)}${options.as ? `\nModel alias: ${color.configVar(options.as)}` : ''}`)
 
   ux.log(
     `Run ${color.cmd(`'heroku config -a ${addon.app.name}'`)} to view model config vars associated with this app.`

--- a/test/commands/ai/models/create.test.ts
+++ b/test/commands/ai/models/create.test.ts
@@ -85,7 +85,7 @@ describe('ai:models:create', function () {
       expect(stripAnsi(stdout.output)).to.eq(heredoc`
         Heroku AI model resource provisioned successfully
         Resource name: inference-regular-74659
-        Model alias: CLAUDE_HAIKU
+        Resource alias: CLAUDE_HAIKU
         Run 'heroku config -a app1' to view model config vars associated with this app.
         Use heroku ai:docs to view documentation.
       `)
@@ -123,7 +123,7 @@ describe('ai:models:create', function () {
       expect(stripAnsi(stdout.output)).to.eq(heredoc`
         Heroku AI model resource provisioned successfully
         Resource name: inference-regular-74659
-        Model alias: CLAUDE_HAIKU
+        Resource alias: CLAUDE_HAIKU
         Run 'heroku config -a app1' to view model config vars associated with this app.
         Use heroku ai:docs to view documentation.
       `)
@@ -151,7 +151,7 @@ describe('ai:models:create', function () {
       expect(stripAnsi(stdout.output)).to.eq(heredoc`
         Heroku AI model resource provisioned successfully
         Resource name: inference-regular-74659
-        Model alias: CLAUDE_HAIKU
+        Resource alias: CLAUDE_HAIKU
         Run 'heroku config -a app1' to view model config vars associated with this app.
         Use heroku ai:docs to view documentation.
       `)

--- a/test/commands/ai/models/create.test.ts
+++ b/test/commands/ai/models/create.test.ts
@@ -52,7 +52,7 @@ describe('ai:models:create', function () {
       `)
       expect(stripAnsi(stdout.output)).to.eq(heredoc`
         Heroku AI model resource provisioned successfully
-        Model name: inference-regular-74659
+        Resource name: inference-regular-74659
         Run 'heroku config -a app1' to view model config vars associated with this app.
         Use heroku ai:docs to view documentation.
       `)
@@ -84,7 +84,7 @@ describe('ai:models:create', function () {
       `)
       expect(stripAnsi(stdout.output)).to.eq(heredoc`
         Heroku AI model resource provisioned successfully
-        Model name: inference-regular-74659
+        Resource name: inference-regular-74659
         Model alias: CLAUDE_HAIKU
         Run 'heroku config -a app1' to view model config vars associated with this app.
         Use heroku ai:docs to view documentation.
@@ -122,7 +122,7 @@ describe('ai:models:create', function () {
       expect(stripAnsi(stderr.output)).to.contain('Adding CLAUDE_HAIKU to app app1 would overwrite existing vars')
       expect(stripAnsi(stdout.output)).to.eq(heredoc`
         Heroku AI model resource provisioned successfully
-        Model name: inference-regular-74659
+        Resource name: inference-regular-74659
         Model alias: CLAUDE_HAIKU
         Run 'heroku config -a app1' to view model config vars associated with this app.
         Use heroku ai:docs to view documentation.
@@ -150,7 +150,7 @@ describe('ai:models:create', function () {
       expect(stripAnsi(stderr.output)).not.to.contain('Adding CLAUDE_HAIKU to app app1 would overwrite existing vars')
       expect(stripAnsi(stdout.output)).to.eq(heredoc`
         Heroku AI model resource provisioned successfully
-        Model name: inference-regular-74659
+        Resource name: inference-regular-74659
         Model alias: CLAUDE_HAIKU
         Run 'heroku config -a app1' to view model config vars associated with this app.
         Use heroku ai:docs to view documentation.


### PR DESCRIPTION
## Description
[Work Item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000028ohtwYAA/view)

This PR updates the outputted property name from `Model name` to `Resource name` for the `heroku ai:models:create` command.

## Testing
- Pull down branch & `yarn` it up
- Create a model via `./bin/run ai:models:create claude-3-5-haiku --as MY_EXAMPLE_MODEL --app <app name>`
- Confirm that the outputted property says `Resource name` and not `Model name`