### PR TITLE
Update generic error for models by region

### DIFF
--- a/src/lib/ai/models/util.ts
+++ b/src/lib/ai/models/util.ts
@@ -37,7 +37,7 @@ export function handlePlatformApiErrors(error: unknown, cmdContext: {as?: string
 
     if (cmdContext.modelName && error.body.message?.includes('add-on plan')) {
       ux.error(
-        `${cmdContext.modelName} is an invalid model name. Run ${color.cmd('heroku ai:models:list')} for a list of valid models.`,
+        `${cmdContext.modelName} is an invalid model name. Run ${color.cmd('heroku ai:models:list')} for a list of valid models per region.`,
         {exit: 1},
       )
     }

--- a/test/commands/ai/models/create.test.ts
+++ b/test/commands/ai/models/create.test.ts
@@ -239,7 +239,7 @@ describe('ai:models:create', function () {
       } catch (error: unknown) {
         const {message, oclif} = error as CLIError
         expect(stripAnsi(message)).to.eq(
-          'not-a-model-name is an invalid model name. Run heroku ai:models:list for a list of valid models.'
+          'not-a-model-name is an invalid model name. Run heroku ai:models:list for a list of valid models per region.'
         )
         expect(oclif.exit).to.eq(1)
       }


### PR DESCRIPTION
## Description
[Work Item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000028opWeYAI/view)

This PR updates the generic model error message for the `heroku ai:models:create` command. It appends `per region` to the error message to hint to the user that they're either entering an incorrect model name OR an incorrect model for the region. This will improve UX.

## Testing
- Pull down branch & `yarn` it up
- Surface generic error via `./bin/run ai:models:create invalid-model-name --app <app name>`
- Confirm that the error output includes the updated `per region` text. 