### PR TITLE
Add supported regions

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "scripts": {
     "build": "rm -rf dist && tsc -b && oclif manifest && oclif readme && mv oclif.manifest.json ./dist/oclif.manifest.json && cp README.md ./dist/README.md",
     "lint": "eslint . --ext .ts --config .eslintrc.json",
+    "lint:fix": "eslint . --ext .ts --config .eslintrc.json --fix",
     "prepare": "yarn build",
     "posttest": "yarn lint",
     "test": "nyc mocha --forbid-only",

--- a/src/commands/ai/models/list.ts
+++ b/src/commands/ai/models/list.ts
@@ -11,6 +11,9 @@ const displayModels = (models: ModelList) => {
     type: {
       get: ({type}: any) => type.join(', '),
     },
+    region: {
+      get: ({regions}: any) => regions.join(', '),
+    }
   }, {'no-header': false})
 }
 

--- a/src/commands/ai/models/list.ts
+++ b/src/commands/ai/models/list.ts
@@ -11,9 +11,9 @@ const displayModels = (models: ModelList) => {
     type: {
       get: ({type}: any) => type.join(', '),
     },
-    region: {
+    regions: {
       get: ({regions}: any) => regions.join(', '),
-    }
+    },
   }, {'no-header': false})
 }
 

--- a/src/commands/ai/models/list.ts
+++ b/src/commands/ai/models/list.ts
@@ -11,7 +11,7 @@ const displayModels = (models: ModelList) => {
     type: {
       get: ({type}: any) => type.join(', '),
     },
-    regions: {
+    supported_regions: {
       get: ({regions}: any) => regions.join(', '),
     },
   }, {'no-header': false})

--- a/test/commands/ai/models/list.test.ts
+++ b/test/commands/ai/models/list.test.ts
@@ -29,7 +29,7 @@ describe('ai:models:list', function () {
 
     await runCommand(Cmd)
 
-    expect(stdout.output).to.match(/Model\s+Type\s+Region/)
+    expect(stdout.output).to.match(/Model\s+Type\s+Regions/)
 
     expect(stdout.output).to.match(/claude-3-5-sonnet\s+text-to-text\s+eu-central-1, us-east-1/)
     expect(stdout.output).to.match(/claude-3-5-sonnet-latest\s+text-to-text\s+us-east-1/)

--- a/test/commands/ai/models/list.test.ts
+++ b/test/commands/ai/models/list.test.ts
@@ -28,12 +28,16 @@ describe('ai:models:list', function () {
       .reply(200, availableModels)
 
     await runCommand(Cmd)
-    expect(stdout.output).to.match(/claude-3-5-haiku\s+text-to-text/)
-    expect(stdout.output).to.match(/claude-3-5-sonnet\s+text-to-text/)
-    expect(stdout.output).to.match(/claude-3-5-sonnet-latest\s+text-to-text/)
-    expect(stdout.output).to.match(/claude-3-haiku\s+text-to-text/)
-    expect(stdout.output).to.match(/cohere-embed-multilingual\s+text-to-embedding/)
-    expect(stdout.output).to.match(/stable-image-ultra\s+text-to-image/)
+
+    expect(stdout.output).to.match(/Model\s+Type\s+Region/)
+
+    expect(stdout.output).to.match(/claude-3-5-sonnet\s+text-to-text\s+eu-central-1, us-east-1/)
+    expect(stdout.output).to.match(/claude-3-5-sonnet-latest\s+text-to-text\s+us-east-1/)
+    expect(stdout.output).to.match(/claude-3-haiku\s+text-to-text\s+eu-central-1, us-east-1/)
+    expect(stdout.output).to.match(/claude-3-5-haiku\s+text-to-text\s+us-east-1/)
+    expect(stdout.output).to.match(/cohere-embed-multilingual\s+text-to-embedding\s+us-east-1/)
+    expect(stdout.output).to.match(/stable-image-ultra\s+text-to-image\s+eu-central-1, us-east-1/)
+
     expect(stdout.output).to.contain('See https://devcenter.heroku.com/articles/heroku-inference-api-model-cards for more info')
     expect(stderr.output).to.eq('')
   })

--- a/test/commands/ai/models/list.test.ts
+++ b/test/commands/ai/models/list.test.ts
@@ -29,7 +29,7 @@ describe('ai:models:list', function () {
 
     await runCommand(Cmd)
 
-    expect(stdout.output).to.match(/Model\s+Type\s+Regions/)
+    expect(stdout.output).to.match(/Model\s+Type\s+Supported regions/)
 
     expect(stdout.output).to.match(/claude-3-5-sonnet\s+text-to-text\s+eu-central-1, us-east-1/)
     expect(stdout.output).to.match(/claude-3-5-sonnet-latest\s+text-to-text\s+us-east-1/)

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -5,26 +5,32 @@ export const availableModels = [
   {
     model_id: 'claude-3-5-sonnet',
     type: ['text-to-text'],
+    regions: ['eu-central-1', 'us-east-1'],
   },
   {
     model_id: 'claude-3-5-sonnet-latest',
     type: ['text-to-text'],
+    regions: ['us-east-1'],
   },
   {
     model_id: 'claude-3-haiku',
     type: ['text-to-text'],
+    regions: ['eu-central-1', 'us-east-1'],
   },
   {
     model_id: 'claude-3-5-haiku',
     type: ['text-to-text'],
+    regions: ['us-east-1'],
   },
   {
     model_id: 'cohere-embed-multilingual',
     type: ['text-to-embedding'],
+    regions: ['us-east-1'],
   },
   {
     model_id: 'stable-image-ultra',
     type: ['text-to-image'],
+    regions: ['eu-central-1', 'us-east-1'],
   },
 ]
 


### PR DESCRIPTION
## Description
[Work Item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000026ui1BYAQ/view)

This PR adds supported regions to the `heroku ai:models:list` command with an added column.

NOTE: Also added a `lint:fix` script for future linting issues.

## Testing
1. Pull down branch & `yarn` it up!
2. Check that the new `Regions` column is present via `./bin/run ai:models:list`