### PR TITLE
feat: Removes pilot messaging and shows pricing as metered

### DIFF
--- a/src/commands/ai/models/create.ts
+++ b/src/commands/ai/models/create.ts
@@ -36,12 +36,6 @@ export default class Create extends Command {
     const {app, as, confirm} = flags
     const {model_name: modelName} = args
 
-    ux.warn(heredoc`
-      Heroku Managed Inference and Agent is a pilot or beta service that is subject to the Beta Services Terms at https://www.salesforce.com/company/legal/customer-agreements/ or a written Unified Pilot Agreement if executed by Customer, and the Non-GA Gen AI and Non-GA Credit Consumption terms in the Product Terms Directory at https://ptd.salesforce.com. While use of this pilot or beta service is itself free, such use may consume GA Heroku credits and/or resources for which the Customer may have paid or be charged. Use of this pilot or beta is at the Customer's sole discretion.
-      
-      For clarity and without limitation, the various third-party machine learning and generative artificial intelligence (AI) models and applications (each a “Platform”) integrated with the Beta Service are Non-SFDC Applications, as that term is defined in the Beta Services Terms. Note that these third-party Platforms include features that use generative AI technology. Due to the nature of generative AI, the output that a Platform generates may be unpredictable, and may include inaccurate or harmful responses. Before using any generative AI output, Customer is solely responsible for reviewing the output for accuracy, safety, and compliance with applicable laws and third-party acceptable use policies. In addition, Customer’s use of each Platform may be subject to the Platform’s own terms and conditions, compliance with which Customer is solely responsible.
-    `)
-
     try {
       const addon = await createAddon(
         this.heroku,

--- a/src/lib/ai/models/create_addon.ts
+++ b/src/lib/ai/models/create_addon.ts
@@ -34,7 +34,11 @@ export default async function (
       throw error
     })
 
-    ux.action.stop(color.green(util.formatPriceText(addon.plan?.price || '')))
+    // TODO: This is a hack to show 'metered' as the price text.
+    // We should rely on the information returned from the API, but here we use a legacy
+    // variant for the add-on serialization and only variant '3.sdk' returns metered pricing.
+    // ux.action.stop(color.green(util.formatPriceText(addon.plan?.price || '')))
+    ux.action.stop(color.green('metered'))
 
     return addon
   }

--- a/test/commands/ai/models/create.test.ts
+++ b/test/commands/ai/models/create.test.ts
@@ -44,11 +44,8 @@ describe('ai:models:create', function () {
         'claude-3-haiku',
         '--app=app1',
       ])
-      expect(stripAnsi(stderr.output)).to.include(
-        'Heroku Managed Inference and Agent is a pilot or beta service'
-      )
       expect(stripAnsi(stderr.output)).to.include(heredoc`
-        Creating heroku-inference:claude-3-haiku on app1... free
+        Creating heroku-inference:claude-3-haiku on app1... metered
       `)
       expect(stripAnsi(stdout.output)).to.eq(heredoc`
         Heroku AI model resource provisioned successfully
@@ -76,11 +73,8 @@ describe('ai:models:create', function () {
         '--app=app1',
         '--as=CLAUDE_HAIKU',
       ])
-      expect(stripAnsi(stderr.output)).to.include(
-        'Heroku Managed Inference and Agent is a pilot or beta service'
-      )
       expect(stripAnsi(stderr.output)).to.include(heredoc`
-        Creating heroku-inference:claude-3-haiku on app1... free
+        Creating heroku-inference:claude-3-haiku on app1... metered
       `)
       expect(stripAnsi(stdout.output)).to.eq(heredoc`
         Heroku AI model resource provisioned successfully


### PR DESCRIPTION
## Description

This PR removes the pilot and beta service messaging that was displayed on model creation (`heroku ai:models:create`).

We're also including a change to show the pricing as `metered`, previously it was showing `free`. We hardcoded this because we cannot rely on the API response. Ideally, we'll use the `3.sdk` variant which includes metered pricing info on the response and we'd modify the formatting function to show the right legend, but add-on creation uses a legacy variant to get the add-on provider's provisioning message that hasn't been incorporated to the `3.sdk` variant. Hardcoding that here isn't a problem because this command is solely used to create model resources which are always metered at this point.

## Testing

### Preparation
- Pull this branch
- Run `yarn` and `yarn build`.
- Install/Update the Heroku CLI Plugin AI: `heroku plugins:install @heroku/plugin-ai`.

### Run tests
- Run `heroku ai:models:create claude-3-5-haiku -a <test-app>`. You should see a notice apropos the pilot service and the add-on pricing as `free`.
- Run the same command on this branch: `./bin/run ai:models:create claude-3-5-haiku -a <test-app>`, you shouldn't see the notice and the pricing should read `metered`.
- Destroy the created add-ons used for testing.

## SOC2 Compliance
GUS Work Item: [W-18456164](https://gus.lightning.force.com/a07EE00002E0vurYAB)