### PR TITLE
feat: adds heroku ai:mcp and heroku ai:tools:list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ USAGE
 # Commands
 <!-- commands -->
 * [`heroku ai:docs`](#heroku-aidocs)
+* [`heroku ai:mcp`](#heroku-aimcp)
 * [`heroku ai:models`](#heroku-aimodels)
 * [`heroku ai:models:attach MODEL_RESOURCE`](#heroku-aimodelsattach-model_resource)
 * [`heroku ai:models:call MODEL_RESOURCE`](#heroku-aimodelscall-model_resource)
@@ -34,6 +35,7 @@ USAGE
 * [`heroku ai:models:detach MODEL_RESOURCE`](#heroku-aimodelsdetach-model_resource)
 * [`heroku ai:models:info [MODEL_RESOURCE]`](#heroku-aimodelsinfo-model_resource)
 * [`heroku ai:models:list`](#heroku-aimodelslist)
+* [`heroku ai:tools:list [ADDON]`](#heroku-aitoolslist-addon)
 
 ## `heroku ai:docs`
 
@@ -51,6 +53,24 @@ DESCRIPTION
 ```
 
 _See code: [src/commands/ai/docs.ts](https://github.com/heroku/heroku-cli-plugin-ai/blob/v0.0.11/src/commands/ai/docs.ts)_
+
+## `heroku ai:mcp`
+
+list all available AI tools
+
+```
+USAGE
+  $ heroku ai:mcp -a <value> [--json]
+
+FLAGS
+  -a, --app=<value>  (required) app to list tools for
+      --json         output in JSON format
+
+DESCRIPTION
+  list all available AI tools
+```
+
+_See code: [src/commands/ai/mcp/index.ts](https://github.com/heroku/heroku-cli-plugin-ai/blob/v0.0.11/src/commands/ai/mcp/index.ts)_
 
 ## `heroku ai:models`
 
@@ -256,4 +276,25 @@ EXAMPLES
 ```
 
 _See code: [src/commands/ai/models/list.ts](https://github.com/heroku/heroku-cli-plugin-ai/blob/v0.0.11/src/commands/ai/models/list.ts)_
+
+## `heroku ai:tools:list [ADDON]`
+
+list all available AI tools
+
+```
+USAGE
+  $ heroku ai:tools:list [ADDON] -a <value> [--json]
+
+ARGUMENTS
+  ADDON  [default: heroku-inference] unique identifier or globally unique name of the add-on. If omitted
+
+FLAGS
+  -a, --app=<value>  (required) app to list tools for
+      --json         output in JSON format
+
+DESCRIPTION
+  list all available AI tools
+```
+
+_See code: [src/commands/ai/tools/list.ts](https://github.com/heroku/heroku-cli-plugin-ai/blob/v0.0.11/src/commands/ai/tools/list.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "repository": "heroku/heroku-cli-plugin-ai",
   "scripts": {
     "build": "rm -rf dist && tsc -b && oclif manifest && oclif readme && mv oclif.manifest.json ./dist/oclif.manifest.json && cp README.md ./dist/README.md",
+    "build:dev": "rm -rf dist && tsc -b --sourcemap && oclif manifest && oclif readme && mv oclif.manifest.json ./dist/oclif.manifest.json && cp README.md ./dist/README.md",
     "lint": "eslint . --ext .ts --config .eslintrc.json",
     "lint:fix": "eslint . --ext .ts --config .eslintrc.json --fix",
     "prepare": "yarn build",

--- a/src/commands/ai/mcp/index.ts
+++ b/src/commands/ai/mcp/index.ts
@@ -1,0 +1,28 @@
+import {flags} from '@heroku-cli/command'
+import Command from '../../../lib/base'
+
+export default class MCP extends Command {
+  public static description = 'list all available AI tools'
+  public static flags = {
+    json: flags.boolean({
+      description: 'output in JSON format',
+    }),
+    app: flags.app({
+      description: 'app to list tools for',
+      required: true,
+    }),
+  }
+
+  public async run() {
+    const {flags} = await this.parse(MCP)
+    const {body: config} = await this.heroku.get<Record<string, string>>(`/apps/${flags.app}/config-vars`)
+
+    if (config.INFERENCE_MCP_URL) {
+      this.log(config.INFERENCE_MCP_URL)
+    } else if (config.INFERENCE_URL) {
+      this.log(config.INFERENCE_URL + '/mcp')
+    } else {
+      this.log(`No MCP server URL found for ${flags.app}`)
+    }
+  }
+}

--- a/src/commands/ai/models/info.ts
+++ b/src/commands/ai/models/info.ts
@@ -30,7 +30,7 @@ export default class Info extends Command {
     let listOfProvisionedModels: Array<ModelResource>  = []
 
     const modelInfo = async () => {
-      const modelInfoResponse = await this.herokuAI.get<ModelResource>(`/models/${this.apiModelId}`, {
+      const modelInfoResponse = await this.herokuAI.get<ModelResource>(`/models/${this.addon.id}`, {
         headers: {authorization: `Bearer ${this.apiKey}`},
       })
         .catch(error => {

--- a/src/commands/ai/tools/list.ts
+++ b/src/commands/ai/tools/list.ts
@@ -1,0 +1,49 @@
+import {flags} from '@heroku-cli/command'
+import Command from '../../../lib/base'
+import {MCPServerList, MCPServerTool} from '../../../lib/ai/types'
+import {Args, ux} from '@oclif/core'
+
+export default class List extends Command {
+  public static description = 'list all available AI tools'
+  public static flags = {
+    json: flags.boolean({
+      description: 'output in JSON format',
+    }),
+    app: flags.app({
+      description: 'app to list tools for',
+      required: true,
+    }),
+  }
+
+  static args = {
+    addon: Args.string({
+      required: false,
+      default: 'heroku-inference',
+      description: 'unique identifier or globally unique name of the add-on. If omitted',
+    }),
+  };
+
+  public async run() {
+    const {flags, args} = await this.parse(List)
+    const tools = await this.getTools(flags.app, args.addon)
+
+    if (flags.json) {
+      ux.styledJSON(tools)
+    } else if (tools.length === 0) {
+      ux.info('No AI tools are currently available for this app')
+    } else {
+      ux.table(tools, {
+        namespaced_name: {header: 'Tool', get: tool => tool.namespaced_name},
+        description: {header: 'Description', get: tool => tool.description},
+      })
+    }
+  }
+
+  private async getTools(app: string, addon: string): Promise<MCPServerTool[]> {
+    await this.configureHerokuAIClient(addon, app)
+
+    const {body: servers} = await this.herokuAI.get<MCPServerList>('/v1/mcp/servers')
+
+    return servers.flatMap(server => server.tools)
+  }
+}

--- a/src/commands/ai/tools/list.ts
+++ b/src/commands/ai/tools/list.ts
@@ -33,8 +33,8 @@ export default class List extends Command {
       ux.info('No AI tools are currently available for this app')
     } else {
       ux.table(tools, {
-        namespaced_name: {header: 'Tool', get: tool => tool.namespaced_name},
-        description: {header: 'Description', get: tool => tool.description},
+        namespaced_name: {header: 'Tool', get: tool => tool?.namespaced_name},
+        description: {header: 'Description', get: tool => tool?.description},
       })
     }
   }

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -316,3 +316,28 @@ export type EmbeddingResponse = {
     readonly total_tokens: number
   }
 }
+
+// MCP Server API response types
+
+export type MCPServerTool = {
+  name: string;
+  namespaced_name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+  annotations: Record<string, unknown>;
+};
+
+export type MCPServer = {
+  id: string;
+  app_id: string;
+  process_type: string;
+  process_command: string;
+  created_at: string;
+  updated_at: string;
+  tools: MCPServerTool[];
+  server_status: 'registered' | 'disconnected';
+  primitives_status: 'syncing' | 'synced' | 'error';
+  namespace: string;
+};
+
+export type MCPServerList = MCPServer[];

--- a/src/lib/base.ts
+++ b/src/lib/base.ts
@@ -94,6 +94,7 @@ export default abstract class extends Command {
 
     this._herokuAI = new APIClient(this.config)
     this._herokuAI.http.defaults = defaults
+    this._herokuAI.auth = this._apiKey
   }
 
   /*

--- a/test/commands/ai/mcp/index.test.ts
+++ b/test/commands/ai/mcp/index.test.ts
@@ -1,0 +1,40 @@
+import {expect} from 'chai'
+import {stdout, stderr} from 'stdout-stderr'
+import MCP from '../../../../src/commands/ai/mcp/index'
+import {runCommand} from '../../../run-command'
+import nock from 'nock'
+
+// Helper for Heroku API mock
+const herokuApi = 'https://api.heroku.com'
+
+describe('ai:mcp', function () {
+  let heroku: nock.Scope
+  const app = 'test-app'
+  const configVarsUrl = `/apps/${app}/config-vars`
+
+  beforeEach(function () {
+    heroku = nock(herokuApi)
+    stdout.start()
+    stderr.start()
+  })
+
+  afterEach(function () {
+    stdout.stop()
+    stderr.stop()
+    nock.cleanAll()
+  })
+
+  it('prints the MCP server URL if INFERENCE_URL is present', async function () {
+    heroku.get(configVarsUrl).reply(200, {INFERENCE_URL: 'https://example.com'})
+    await runCommand(MCP, ['--app', app])
+    expect(stdout.output).to.contain('https://example.com/mcp')
+    expect(stderr.output).to.eq('')
+  })
+
+  it('prints a message if INFERENCE_URL is not present', async function () {
+    heroku.get(configVarsUrl).reply(200, {})
+    await runCommand(MCP, ['--app', app])
+    expect(stdout.output).to.contain(`No MCP server URL found for ${app}`)
+    expect(stderr.output).to.eq('')
+  })
+})

--- a/test/commands/ai/models/info.test.ts
+++ b/test/commands/ai/models/info.test.ts
@@ -39,7 +39,7 @@ describe('ai:models:info', function () {
           INFERENCE_URL: 'us.inference.heroku.com',
         })
       herokuAI
-        .get('/models/claude-3-haiku')
+        .get(`/models/${addon1.id}`)
         .reply(200, modelResource)
 
       await runCommand(Cmd, [
@@ -91,7 +91,7 @@ describe('ai:models:info', function () {
           INFERENCE_URL: 'us.inference.heroku.com',
         })
       herokuAI
-        .get('/models/claude-3-haiku')
+        .get(`/models/${addon1.id}`)
         .reply(200, modelResource)
       api
         .get(`/apps/${addon1.app?.name}/addons`)
@@ -108,7 +108,7 @@ describe('ai:models:info', function () {
           INFERENCE_URL: 'us.inference.heroku.com',
         })
       herokuAI
-        .get('/models/claude-3-haiku')
+        .get(`/models/${addon1.id}`)
         .reply(200, modelResource)
 
       await runCommand(Cmd, [

--- a/test/commands/ai/tools/list.test.ts
+++ b/test/commands/ai/tools/list.test.ts
@@ -1,0 +1,144 @@
+import {expect} from 'chai'
+import {stdout, stderr} from 'stdout-stderr'
+import ListCmd from '../../../../src/commands/ai/tools/list'
+import {runCommand} from '../../../run-command'
+import nock from 'nock'
+import {CLIError} from '@oclif/core/lib/errors'
+
+const mockConfigVars = {
+  INFERENCE_KEY: 'fake-key',
+  INFERENCE_MODEL_ID: 'fake-model',
+  INFERENCE_URL: 'https://us.inference.heroku.com',
+}
+
+const mockServers = [
+  {
+    id: 'server-1',
+    app_id: 'app-1',
+    process_type: 'web',
+    process_command: 'python app.py',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    tools: [
+      {
+        name: 'summarize',
+        namespaced_name: 'heroku-inference.summarize',
+        description: 'Summarize text',
+        input_schema: {text: {type: 'string'}},
+        annotations: {},
+      },
+      {
+        name: 'classify',
+        namespaced_name: 'heroku-inference.classify',
+        description: 'Classify text',
+        input_schema: {text: {type: 'string'}},
+        annotations: {},
+      },
+    ],
+    server_status: 'registered',
+    primitives_status: 'synced',
+    namespace: 'heroku-inference',
+  },
+]
+
+describe('ai:tools:list', function () {
+  const {env} = process
+  let herokuAPI: nock.Scope
+
+  beforeEach(function () {
+    process.env = {}
+    herokuAPI = nock('https://api.heroku.com')
+    nock('https://us.inference.heroku.com')
+    stdout.start()
+    stderr.start()
+  })
+
+  afterEach(function () {
+    process.env = env
+    nock.cleanAll()
+    stdout.stop()
+    stderr.stop()
+  })
+
+  function mockAddonAndConfig(app = 'my-app', addon = 'heroku-inference') {
+    herokuAPI
+      .post('/actions/addons/resolve')
+      .reply(200, [{
+
+        id: 'addon-1',
+        name: addon,
+        app: {id: 'app-1', name: app},
+        addon_service: {id: 'service-1', name: 'heroku-inference'},
+        plan: {id: 'plan-1', name: 'heroku-inference:basic'}
+        ,
+      }])
+    herokuAPI
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, [{
+
+        id: 'attach-1',
+        name: 'INFERENCE',
+        app: {id: 'app-1', name: app},
+        addon: {id: 'addon-1', name: addon, app: {id: 'app-1', name: app}}
+        ,
+      }])
+    herokuAPI
+      .get('/apps/app-1/config-vars')
+      .reply(200, mockConfigVars)
+  }
+
+  it('lists all available tools in table format', async function () {
+    mockAddonAndConfig()
+    nock('https://us.inference.heroku.com')
+      .get('/v1/mcp/servers')
+      .reply(200, mockServers)
+
+    await runCommand(ListCmd, ['--app', 'my-app'])
+
+    expect(stdout.output).to.match(/Tool\s+Description/)
+    expect(stdout.output).to.match(/heroku-inference.summarize\s+Summarize text/)
+    expect(stdout.output).to.match(/heroku-inference.classify\s+Classify text/)
+    expect(stderr.output).to.eq('')
+  })
+
+  it('lists all available tools in JSON format', async function () {
+    mockAddonAndConfig()
+    nock('https://us.inference.heroku.com')
+      .get('/v1/mcp/servers')
+      .reply(200, mockServers)
+
+    await runCommand(ListCmd, ['--app', 'my-app', '--json'])
+
+    expect(() => JSON.parse(stdout.output)).not.to.throw()
+    const output = JSON.parse(stdout.output)
+    expect(output).to.be.an('array')
+    expect(output[0].tools).to.be.undefined // Should be flat array of tools
+    expect(output[0].namespaced_name).to.equal('heroku-inference.summarize')
+  })
+
+  it('shows info if no tools are available', async function () {
+    mockAddonAndConfig()
+    nock('https://us.inference.heroku.com')
+      .get('/v1/mcp/servers')
+      .reply(200, [{...mockServers[0], tools: []}])
+
+    await runCommand(ListCmd, ['--app', 'my-app'])
+
+    expect(stdout.output).to.match(/No AI tools are currently available/)
+  })
+
+  it('handles API errors gracefully', async function () {
+    mockAddonAndConfig()
+    nock('https://us.inference.heroku.com')
+      .get('/v1/mcp/servers')
+      .reply(500, {message: 'Internal Server Error'})
+
+    try {
+      await runCommand(ListCmd, ['--app', 'my-app'])
+    } catch (error) {
+      const err = error as CLIError
+      expect(err).to.be.instanceOf(CLIError)
+      expect(err.message).to.match(/Internal Server Error/)
+    }
+  })
+})


### PR DESCRIPTION
[W-18453773](https://gus.lightning.force.com/a07EE00002E095rYAB)
[W-18453729](https://gus.lightning.force.com/a07EE00002E01ugYAB)
# PR Description

## 1. Overview
This PR introduces two new CLI commands to enhance the Heroku AI integration experience:
- Listing all available AI tools for a given app and MIA (Model Inference Add-on) via the MCP (Model Context Protocol) endpoint.
- Fetching and displaying the unique MCP endpoint URL associated with a Heroku MIA addon.

## 2. Key Features
- `ai:tools:list`: Lists all available AI tools (enabled and disabled) for a specified app and addon, including their status and descriptions.
- `ai:mcp`: Retrieves and displays the MCP endpoint URL for a given app, which serves as the central gateway for all configured AI tools.

## 3. Technical Details
- **Implementation**:
  - `ai:tools:list` fetches the list of tools from the MCP server endpoint (`/v1/mcp/servers`) after configuring the Heroku AI client with the correct addon and app context.
  - `ai:mcp` retrieves the MCP URL from the app's config vars (`INFERENCE_MCP_URL` or falls back to `INFERENCE_URL + '/mcp'`).
- **Error Handling**:
  - If no tools are available, a user-friendly message is displayed.
  - If no MCP URL is found in the config vars, a clear error message is shown.
- **Configuration**:
  - Both commands require the `--app` flag to specify the target Heroku app.
  - The `ai:tools:list` command allows specifying an addon (defaults to `heroku-inference`).

## 4. Testing Instructions
### Prerequisites
- Ensure the Heroku CLI is installed and authenticated.
- The target app must have the MIA addon installed and properly configured.

### Test Scenarios
1. **List Tools (Success)**
   - Run: `heroku ai:tools:list --app <app-name>`
   - Expected: Table or JSON output of all available tools with their names and descriptions.
2. **List Tools (No Tools)**
   - Run: `heroku ai:tools:list --app <app-name>` (on an app with no tools)
   - Expected: Message "No AI tools are currently available for this app".
3. **List Tools (JSON Output)**
   - Run: `heroku ai:tools:list --app <app-name> --json`
   - Expected: JSON array of tool objects.
4. **Fetch MCP URL (Success)**
   - Run: `heroku ai:mcp --app <app-name>`
   - Expected: MCP URL is printed.
5. **Fetch MCP URL (No URL)**
   - Run: `heroku ai:mcp --app <app-name>` (on an app without the relevant config vars)
   - Expected: Message "No MCP server URL found for <app-name>".

## 5. Impact
- Provides visibility into all AI tools available for integration, improving transparency and manageability.
- Simplifies discovery of the MCP endpoint, aiding in debugging and integration.
- Enhances user experience for developers working with Heroku AI add-ons.

## 6. Future Considerations
- Support for filtering tools by status (enabled/disabled).
- Enhanced error reporting for network or permission issues.
- Option to display additional tool metadata (e.g., version, last updated).

## 7. Related Documentation
- [Heroku CLI Command Reference](https://devcenter.heroku.com/articles/heroku-cli-commands)
- [Heroku Add-ons Documentation](https://devcenter.heroku.com/articles/add-ons)
- [Model Context Protocol (MCP) API Docs](https://devcenter.heroku.com/articles/inference)